### PR TITLE
Ajout d'un fichier .zip aux Releases GitHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,18 @@ jobs:
           name: Push to the Docker Hub registry
           command: docker push $IMAGE:$CIRCLE_SHA1 && docker push $IMAGE:latest
 
+  publish:
+    machine: true
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Zip and publish the built files to Github Releases
+          command: |
+            cd dist &&
+            chmod +x ../release.sh &&
+            ../release.sh
+
 workflows:
   version: 2
   test_build_deploy:
@@ -99,3 +111,11 @@ workflows:
             branches:
               only:
                 - master
+      - publish:
+          requires:
+            - build
+            - test
+          filters:
+            tags:
+              only:
+                - /^v.*/

--- a/release.sh
+++ b/release.sh
@@ -25,7 +25,6 @@ curl -i -s -X POST -H "Content-Type:application/json" -H "Authorization: token $
 # Get the assets upload URL and truncate the last weird part
 UPLOAD_URL=$(curl -sS "${RELEASES_URL}/tags/${CIRCLE_TAG}" | jq -r '.upload_url' | cut -d{ -f1)
 # Build the actual upload URL from it
-LABEL="transpiled_files_to_serve_from_a_Web_Server"
 ASSET_URL="${UPLOAD_URL}/assets?name=${FILENAME}"
 # Send the file as binary in the request body
 curl -i -X POST -H "Content-Type:application/zip" -H "Authorization: token ${GITHUB_API_TOKEN}" ${ASSET_URL} --data-binary "@${FILENAME}"

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+FILENAME="hackafront${CIRCLE_TAG}.zip"
+# Add all files and folders, recursively, to $FILENAME 
+zip -r ${FILENAME} *
+
+# Make sure the release has already been created, otherwise create it
+RELEASES_URL="https://api.github.com/repos/socialement-competents/hackafront/releases"
+PAYLOAD='{"tag_name":"'${CIRCLE_TAG}'","target_commitish":"'${CIRCLE_BRANCH}'","name":"'${CIRCLE_TAG}'","draft":false,"prerelease":false}'
+curl -i -X POST -H "Content-Type:application/json" -H "Authorization: token ${GITHUB_API_TOKEN}" ${RELEASES_URL} -d ${PAYLOAD}
+
+# Get the assets upload URL and truncate the last weird part
+UPLOAD_URL=$(curl -s "https://api.github.com/repos/socialement-competents/hackafront/releases/tags/${CIRCLE_TAG}" | jq -r '.upload_url' | cut -d{ -f1)
+# Build the actual upload URL from it
+LABEL="transpiled_files_to_serve_from_a_Web_Server"
+ASSET_URL="${UPLOAD_URL}/assets?name=${FILENAME}&label=${LABEL}"
+# Send the file as binary in the request body
+curl -i -X POST -H "Content-Type:application/zip" -H "Authorization: token ${GITHUB_API_TOKEN}" ${ASSET_URL} --data-binary "@${FILENAME}"

--- a/release.sh
+++ b/release.sh
@@ -1,18 +1,32 @@
 #!/bin/sh
 
-FILENAME="hackafront${CIRCLE_TAG}.zip"
-# Add all files and folders, recursively, to $FILENAME 
+if [ -z "$GITHUB_API_TOKEN" ]; then
+  echo "Please add the GITHUB_API_TOKEN env var"
+  exit 1
+fi
+
+if [ -z "$CIRCLE_TAG" || -z "$CIRCLE_BRANCH" ]; then
+  echo "Run this script in Circle CI (or setup CIRCLE_TAG and CIRCLE_BRANCH manually to test)"
+  exit 1
+fi
+
+ORG=socialement-competents
+REPO=hackafront
+RELEASES_URL=https://api.github.com/repos/${ORG}/${REPO}/releases
+
+# Add all files and folders, recursively, to a tag-named .zip 
+FILENAME="${REPO}-${CIRCLE_TAG}.zip"
 zip -r ${FILENAME} *
 
 # Make sure the release has already been created, otherwise create it
-RELEASES_URL="https://api.github.com/repos/socialement-competents/hackafront/releases"
 PAYLOAD='{"tag_name":"'${CIRCLE_TAG}'","target_commitish":"'${CIRCLE_BRANCH}'","name":"'${CIRCLE_TAG}'","draft":false,"prerelease":false}'
-curl -i -X POST -H "Content-Type:application/json" -H "Authorization: token ${GITHUB_API_TOKEN}" ${RELEASES_URL} -d ${PAYLOAD}
+curl -i -s -X POST -H "Content-Type:application/json" -H "Authorization: token ${GITHUB_API_TOKEN}" ${RELEASES_URL} -d ${PAYLOAD}
 
 # Get the assets upload URL and truncate the last weird part
-UPLOAD_URL=$(curl -s "https://api.github.com/repos/socialement-competents/hackafront/releases/tags/${CIRCLE_TAG}" | jq -r '.upload_url' | cut -d{ -f1)
+UPLOAD_URL=$(curl -sS "${RELEASES_URL}/tags/${CIRCLE_TAG}" | jq -r '.upload_url' | cut -d{ -f1)
 # Build the actual upload URL from it
 LABEL="transpiled_files_to_serve_from_a_Web_Server"
-ASSET_URL="${UPLOAD_URL}/assets?name=${FILENAME}&label=${LABEL}"
+ASSET_URL="${UPLOAD_URL}/assets?name=${FILENAME}"
 # Send the file as binary in the request body
 curl -i -X POST -H "Content-Type:application/zip" -H "Authorization: token ${GITHUB_API_TOKEN}" ${ASSET_URL} --data-binary "@${FILENAME}"
+echo ""


### PR DESCRIPTION
A chaque push avec un `tag` git, GitHub crée automatiquement une release => https://github.com/socialement-competents/hackafront/releases

Cette PR permet, dans CircleCI, à chaque push qui contient au moins 1 tag du style `v1.0.0`, de créer un .zip avec les fichiers transpilés (dossier `dist`) et de l'ajouter à la Release GitHub