### PR TITLE
GitHub releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       IMAGE: "socialementcompetents/hackafront"
     steps:
       - attach_workspace:
-          at: ./dist
+          at: .
       - run:
           name: Connect to Docker Hub
           command: docker login -u $DOCKER_USER -p $DOCKER_PASS
@@ -81,8 +81,7 @@ jobs:
           command: docker push $IMAGE:$CIRCLE_SHA1 && docker push $IMAGE:latest
 
   publish:
-    docker:
-      - image: golang:1.9.6
+    machine: true
     steps:
       - attach_workspace:
           at: .
@@ -90,7 +89,7 @@ jobs:
           name: Zip and publish the built files to Github Releases
           command: |
             apt-get update &&
-            apt-get install -y zip &&
+            apt-get install -y zip bzip2 tar &&
             cd dist &&
             chmod +x ../release.sh &&
             ../release.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,11 @@ jobs:
       - run:
           name: Zip and publish the built files to Github Releases
           command: |
+            apt-get update &&
+            apt-get install -y zip &&
+            ls &&
             cd dist &&
+            ls &&
             chmod +x ../release.sh &&
             ../release.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,7 @@ jobs:
           command: docker push $IMAGE:$CIRCLE_SHA1 && docker push $IMAGE:latest
 
   publish:
-    docker:
-      - image: debian:9.4
+    <<: *node
     steps:
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,10 +90,8 @@ jobs:
           name: Zip and publish the built files to Github Releases
           command: |
             apt-get update &&
-            apt-get install -y zip &&
-            ls &&
+            apt-get install -y zip jq &&
             cd dist &&
-            ls &&
             chmod +x ../release.sh &&
             ../release.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,8 @@ jobs:
       - run:
           name: Zip and publish the built files to Github Releases
           command: |
-            apt-get update &&
-            apt-get install -y zip bzip2 tar &&
+            sudo apt-get update &&
+            sudo apt-get install -y zip bzip2 tar &&
             cd dist &&
             chmod +x ../release.sh &&
             ../release.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,8 @@ jobs:
           command: docker push $IMAGE:$CIRCLE_SHA1 && docker push $IMAGE:latest
 
   publish:
-    machine: true
+    docker:
+      - image: debian:9.4
     steps:
       - attach_workspace:
           at: .
@@ -119,8 +120,6 @@ workflows:
           filters:
             branches:
               only: master
-            tags:
-              only: /.*/
       - publish:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       IMAGE: "socialementcompetents/hackafront"
     steps:
       - attach_workspace:
-          at: .
+          at: ./dist
       - run:
           name: Connect to Docker Hub
           command: docker login -u $DOCKER_USER -p $DOCKER_PASS
@@ -81,7 +81,8 @@ jobs:
           command: docker push $IMAGE:$CIRCLE_SHA1 && docker push $IMAGE:latest
 
   publish:
-    <<: *node
+    docker:
+      - image: golang:1.9.6
     steps:
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           name: Zip and publish the built files to Github Releases
           command: |
             apt-get update &&
-            apt-get install -y zip jq &&
+            apt-get install -y zip &&
             cd dist &&
             chmod +x ../release.sh &&
             ../release.sh

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "unit": "jest --config test/unit/jest.conf.js --coverage",
     "ccov": "codecov -f test/unit/coverage/coverage-final.json $CODECOV_TOKEN",
     "e2e": "node test/e2e/runner.js",
+    "release": "echo \"git commit => git tag -a v1.0.0 -m \"miguel a la plage\" => git push origin --tags\"",
     "test": "npm run unit && npm run e2e",
     "lint": "eslint --ext .ts,.js,.vue src test/unit/specs test/e2e/specs",
     "build": "node build/build.js"

--- a/release.sh
+++ b/release.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-if [ "x${GITHUB_API_TOKEN}" = "x" ]; then
+if [ -z "${GITHUB_API_TOKEN}" ]; then
   echo "Please add the GITHUB_API_TOKEN env var"
   exit 1
 fi
 
-if [ "x${CIRCLE_TAG}" = "x" || "x${CIRCLE_BRANCH}" = "x" ]; then
+if [ -z "${CIRCLE_TAG}" || -z "${CIRCLE_BRANCH}" ]; then
   echo "Run this script in Circle CI (or setup CIRCLE_TAG and CIRCLE_BRANCH manually to test)"
   exit 1
 fi

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-GITHUB_RELEASE_GO=https://github.com/tsauvajon/github-release/releases/download/v0.7.2/linux-amd64-github-release
+GITHUB_RELEASE_GO=https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2
 curl -sL $GITHUB_RELEASE_GO | tar xvjf -
 GR=bin/linux/amd64/github-release
 chmod +x $GR

--- a/release.sh
+++ b/release.sh
@@ -1,32 +1,27 @@
 #!/bin/sh
 
-if [ "x${GITHUB_API_TOKEN}" = "x" ]; then
-  echo "Please add the GITHUB_API_TOKEN env var"
-  exit 1
-fi
+GITHUB_RELEASE_GO=https://github.com/tsauvajon/github-release/releases/download/v0.7.2/linux-amd64-github-release
+# curl -s $GITHUB_RELEASE_GO | tar xvjf -
+# GR=bin/linux/amd64/github-release
+GR=github_release
+curl -s $GITHUB_RELEASE_GO --output $GR
+chmod +x $GR
 
-if [ "x${CIRCLE_TAG}" = "x" || "x${CIRCLE_BRANCH}" = "x" ]; then
-  echo "Run this script in Circle CI (or setup CIRCLE_TAG and CIRCLE_BRANCH manually to test)"
-  exit 1
-fi
-
-ORG=socialement-competents
-REPO=hackafront
-RELEASES_URL=https://api.github.com/repos/${ORG}/${REPO}/releases
+# Create a GitHub release
+$GR release \
+  --user $CIRCLE_PROJECT_USERNAME \
+  --repo $CIRCLE_PROJECT_REPONAME \
+  --tag $CIRCLE_TAG \
+  --name $CIRCLE_TAG
 
 # Add all files and folders, recursively, to a tag-named .zip 
-FILENAME="${REPO}-${CIRCLE_TAG}.zip"
-zip -r ${FILENAME} *
+FILENAME="$REPO-$CIRCLE_TAG.zip"
+zip -r $FILENAME *
 
-# Make sure the release has already been created, otherwise create it
-PAYLOAD='{"tag_name":"'${CIRCLE_TAG}'","target_commitish":"'${CIRCLE_BRANCH}'","name":"'${CIRCLE_TAG}'","draft":false,"prerelease":false}'
-echo ${PAYLOAD}
-curl -i -X POST -H "Content-Type:application/json" -H "Authorization: token ${GITHUB_API_TOKEN}" ${RELEASES_URL} -d ${PAYLOAD}
-
-# Get the assets upload URL and truncate the last weird part
-UPLOAD_URL=$(curl -s "${RELEASES_URL}/tags/${CIRCLE_TAG}" | jq -r '.upload_url' | cut -d{ -f1)
-# Build the actual upload URL from it
-ASSET_URL="${UPLOAD_URL}/assets?name=${FILENAME}"
-# Send the file as binary in the request body
-curl -i -X POST -H "Content-Type:application/zip" -H "Authorization: token ${GITHUB_API_TOKEN}" ${ASSET_URL} --data-binary "@${FILENAME}"
-echo ""
+# Upload the .zip to the release as an asset
+$GR upload \
+  --user $CIRCLE_PROJECT_USERNAME \
+  --repo $CIRCLE_PROJECT_REPONAME \
+  --tag $CIRCLE_TAG \
+  --name $FILENAME \
+  --file $FILENAME

--- a/release.sh
+++ b/release.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-if [ -z "${GITHUB_API_TOKEN}" ]; then
+if [ "x${GITHUB_API_TOKEN}" = "x" ]; then
   echo "Please add the GITHUB_API_TOKEN env var"
   exit 1
 fi
 
-if [ -z "${CIRCLE_TAG}" || -z "${CIRCLE_BRANCH}" ]; then
+if [ "x${CIRCLE_TAG}" = "x" || "x${CIRCLE_BRANCH}" = "x" ]; then
   echo "Run this script in Circle CI (or setup CIRCLE_TAG and CIRCLE_BRANCH manually to test)"
   exit 1
 fi

--- a/release.sh
+++ b/release.sh
@@ -13,7 +13,7 @@ $GR release \
   --name $CIRCLE_TAG
 
 # Add all files and folders, recursively, to a tag-named .zip 
-FILENAME="$REPO-$CIRCLE_TAG.zip"
+FILENAME="$CIRCLE_PROJECT_REPONAME-$CIRCLE_TAG.zip"
 zip -r $FILENAME *
 
 # Upload the .zip to the release as an asset

--- a/release.sh
+++ b/release.sh
@@ -3,7 +3,7 @@
 GITHUB_RELEASE_GO=https://github.com/tsauvajon/github-release/releases/download/v0.7.2/linux-amd64-github-release
 # curl -s $GITHUB_RELEASE_GO | tar xvjf -
 # GR=bin/linux/amd64/github-release
-GR=github_release
+GR=./github_release
 curl -s $GITHUB_RELEASE_GO --output $GR
 chmod +x $GR
 

--- a/release.sh
+++ b/release.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Add all files and folders, recursively, to a tag-named .zip 
+FILENAME="$CIRCLE_PROJECT_REPONAME-$CIRCLE_TAG.zip"
+zip -r $FILENAME *
+
+# Download the github-release executable
 GITHUB_RELEASE_GO=https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2
 curl -sL $GITHUB_RELEASE_GO | tar xvjf -
 GR=bin/linux/amd64/github-release
@@ -11,10 +16,6 @@ $GR release \
   --repo $CIRCLE_PROJECT_REPONAME \
   --tag $CIRCLE_TAG \
   --name $CIRCLE_TAG
-
-# Add all files and folders, recursively, to a tag-named .zip 
-FILENAME="$CIRCLE_PROJECT_REPONAME-$CIRCLE_TAG.zip"
-zip -r $FILENAME *
 
 # Upload the .zip to the release as an asset
 $GR upload \

--- a/release.sh
+++ b/release.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
+# Install github_release
 GITHUB_RELEASE_GO=https://github.com/tsauvajon/github-release/releases/download/v0.7.2/linux-amd64-github-release
-# curl -s $GITHUB_RELEASE_GO | tar xvjf -
-# GR=bin/linux/amd64/github-release
 GR=./github_release
 curl -s $GITHUB_RELEASE_GO --output $GR
 chmod +x $GR

--- a/release.sh
+++ b/release.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 
-# Install github_release
 GITHUB_RELEASE_GO=https://github.com/tsauvajon/github-release/releases/download/v0.7.2/linux-amd64-github-release
-GR=./github_release
-curl -s $GITHUB_RELEASE_GO --output $GR
+curl -sL $GITHUB_RELEASE_GO | tar xvjf -
+GR=bin/linux/amd64/github-release
 chmod +x $GR
 
 # Create a GitHub release


### PR DESCRIPTION
Après un `git tag`, crée un .zip contenant le contenu du répertoire `dist` (fichiers transpilés), crée une release GitHub et ajoute le .zip en tant qu'asset.

Ce fut très difficile. Là y'a moins de la moitié des commits.

Du coup pour publier une release :
```
git commit -am "Message de commit"
git tag -a v0.0.1 -m "Message de release"
git push origin --tags
```